### PR TITLE
Split up Localizable and TextDirection.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12750,43 +12750,68 @@ The {{VoidFunction}} [=callback function=]
 type is used for representing function values that take no arguments and do not
 return any value.
 
-<h3>Locatlizable dictionary</h3>
 
-A localizable member is a dictionary member that represents a bidirectional algorithm paragraph when displayed, as defined by the bidirectional algorithm’s rules P1, P2, and P3, including, for instance, supporting the paragraph-breaking behavior of U+000A LINE FEED (LF) characters.
-
-A user agent is expected to honor the Unicode semantics of localizable members.
-
-The name of a localizable member is left to the defining specification (e.g., "title").
-
-Dictionaries that specify a localizable member must inherit from the {{Localizable}} dictionary.
-
-Specification authors must specify in prose which member(s) of the inheriting dictionary serve as localizable members. It is RECOMMENDED that specification authors limit localizable member in the prototype chain of inherited dictionaries (ideally to one).
+<h3 id="TextDirection" enum>TextDirection</h3>
 
 <pre class="idl">
-enum TextDirection {
-  "auto",
-  "ltr",
-  "rtl"
-};
+    enum TextDirection {
+      "auto",
+      "ltr",
+      "rtl"
+    };
+</pre>
 
-dictionary Localizable {
-  DOMString lang;
-  TextDirection dir = "auto";
-};</pre>
+The {{TextDirection}} [=enumerable=] is used to represent text directionality as described in [[!BIDI]].
 
-The {{lang}} member specifies the primary language for the localizable members in the prototype chain. Its value is a string. The empty string indicates that the primary language is unknown.
-Any other string must be interpreted as a language tag. Validity or well-formedness are not enforced. [[!LANG]]
 
-The {{dir}} member provides the higher-level override of rules P2 and P3 if has a value other than "auto". [[!BIDI]]
+<h3 id="localizable" dictionary>Localizable</h3>
+
+A <dfn export>localizable member</dfn> is a [=dictionary member=] that
+represents a bidirectional algorithm paragraph when displayed,
+as defined by the bidirectional algorithm’s rules P1, P2, and P3,
+including, for instance, supporting the paragraph-breaking behavior
+of <span class="char">U+000A LINE FEED (LF)</span> characters. [[!BIDI]]
+
+A user agent is expected to honor the Unicode semantics of [=localizable members=].
+
+The [=identifier=] of a [=localizable member=] is left to the defining specification (e.g., "title").
+
+Dictionaries that specify a [=localizable member=] must inherit from the {{Localizable}} dictionary.
+
+Specification authors must specify in prose which [=dictionary members|member(s)=]
+of the inheriting dictionary serve as [=localizable members=].
+
+It is recommended that specification authors limit the number of [=dictionary members=]
+that are [=localizable member=], ideally to one.
+
+<pre class="idl">
+    dictionary Localizable {
+      DOMString lang = "";
+      TextDirection dir = "auto";
+    };
+</pre>
+
+The {{Localizable/lang}} member specifies the primary language for the [=dictionary members=]
+which are [=localizable members=].
+Its value is a {{DOMString}}.
+The empty string indicates that the primary language is unknown.
+Any other string must be interpreted as a language tag.
+Validity or well-formedness are not enforced. [[!BCP47]]
+
+The {{Localizable/dir}} member provides the higher-level override of rules P2 and P3
+if it has a value other than <a for=TextDirection enum-value>"auto"</a>. [[!BIDI]]
 
 <div class=example>
-dictionary PaymentItem : Localizable {
-    // "label" is a localizable member
-    required DOMString             label;
-    required PaymentCurrencyAmount amount;
-             boolean               pending = false;
-};
+   <pre highlight="webidl">
+       dictionary PaymentItem : Localizable {
+           // "label" is a localizable member
+           required DOMString label;
+           required PaymentCurrencyAmount amount;
+           boolean pending = false;
+       };
+    </pre>
 </div>
+
 
 <h2 id="extensibility">Extensibility</h2>
 


### PR DESCRIPTION
* Split up Localizable and TextDirection.
* Do most of the cross-linking.
* Remove ES specific references to the "prototype chain".
* Fix broken biblio references.
* Add <small>semantic</small> line breaks.